### PR TITLE
Add setStringConfig method

### DIFF
--- a/__tests__/CookieTest.re
+++ b/__tests__/CookieTest.re
@@ -9,6 +9,15 @@ describe("Cookie", () => {
     |> expect
     |> toBe("test");
   });
+  test(".getAsString can get stuff stored by setStringConfig", () => {
+    Cookie.setStringConfig(
+      "foo",
+      "bar",
+      Cookie.makeConfig(~path="", ~expires=2, ()),
+    );
+    /* Note that it doesn't actualy test the expires, not sure how */
+    Cookie.getAsString("foo") |> expect |> toEqual(Some("bar"));
+  });
   test(".remove can remove a cookie", () => {
     Cookie.setString("hello", "test");
     Cookie.remove("hello");
@@ -29,7 +38,7 @@ describe("Cookie", () => {
     Cookie.setJson("hello", obj);
     Cookie.getAsJson("hello") |> expect |> toEqual(Some(obj));
   });
-  test(".getAsJson can get stuff stored by setJson", () => {
+  test(".getAsJson can get stuff stored by setJsonConfig", () => {
     let obj = Js.Dict.empty();
     Js.Dict.set(obj, "a", Js.Json.number(2.));
     let obj = Js.Json.object_(obj);

--- a/src/Cookie.re
+++ b/src/Cookie.re
@@ -18,7 +18,7 @@ external makeConfig : (~expires: int=?, ~path: string=?, unit) => config = "";
 external setJson : (string, Js.Json.t) => unit = "set";
 
 /*
-   sets a cookie by a name to JSON
+   sets a cookie by a name to JSON with config
  */
 [@bs.module "js-cookie"]
 external setJsonConfig : (string, Js.Json.t, config) => unit = "set";
@@ -27,6 +27,11 @@ external setJsonConfig : (string, Js.Json.t, config) => unit = "set";
   sets a cookie by a name to a string
  */
 [@bs.module "js-cookie"] external setString : (string, string) => unit = "set";
+
+/*
+  sets a cookie by a name to a string with config
+ */
+[@bs.module "js-cookie"] external setStringConfig : (string, string, config) => unit = "set";
 
 /*
   removes a cookie

--- a/src/Cookie.rei
+++ b/src/Cookie.rei
@@ -10,6 +10,8 @@ let setJsonConfig: (string, Js.Json.t, config) => unit;
 
 let setString: (string, string) => unit;
 
+let setStringConfig: (string, string, config) => unit;
+
 let getAsString: string => option(string);
 
 let getAsJson: string => option(Js.Json.t);


### PR DESCRIPTION
### Why did you make these changes?

So you can set a string cookie with config to set a permanent cookie. The current `setString` method only adds a session cookie.

### How can somone test these to make sure they work? (manually, in addition to tests)

Use the new method and make sure the cookie stays in the browser between sessions.

### Note
I only committed changes to `.re` and `.rei` files and left generated files out of this PR.

### Checklist
- [x] I made an issue to talk about this first (or talked to @justgage in some other way such as the discord channel) (someone else did #3)
- [x] I tested my changes
- [x] I avoided making breaking changes when I could
